### PR TITLE
0.98.6 - Bugs found and fixed when trying to run with release Windows 0.98.5 

### DIFF
--- a/clamd/tcpserver.c
+++ b/clamd/tcpserver.c
@@ -112,8 +112,11 @@ int tcpserver(int **lsockets, unsigned int *nlsockets, char *ipaddr, const struc
             serv[0] = '\0';
         }
 #else
-        strncpy(host, ipaddr, sizeof(host));
-        host[sizeof(host)-1] = '\0';
+		if (ipaddr) {
+			strncpy(host, ipaddr, sizeof(host));
+			host[sizeof(host)-1] = '\0';
+		} else
+			host[0] = '\0';
         snprintf(serv, sizeof(serv), "%u", (unsigned int)(optget(opts, "TCPSocket")->numarg));
 #endif
         if(bind(sockfd, p->ai_addr, p->ai_addrlen) == -1) {

--- a/clamdscan/proto.c
+++ b/clamdscan/proto.c
@@ -99,10 +99,9 @@ int dconnect() {
         memset(&hints, 0x00, sizeof(struct addrinfo));
         hints.ai_family = AF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;
-        hints.ai_flags = AI_PASSIVE;
 
         if ((res = getaddrinfo(ipaddr, port, &hints, &info))) {
-            logg("!Could not lookup %s: %s\n", opt->strarg, gai_strerror(res));
+            logg("!Could not lookup %s: %s\n", ipaddr ? ipaddr : "", gai_strerror(res));
             opt = opt->nextarg;
             continue;
         }

--- a/win32/README
+++ b/win32/README
@@ -3,6 +3,16 @@ ClamAV for Win32
 
 --- News ---
 
+In order to support more advanced features planned in future releases, 
+ClamAV has switched to using OpenSSL for hashing. The ClamAV Visual Studio 
+project included with ClamAV's source code requires the OpenSSL 
+distributables to be placed in a specific directory. This article will 
+teach you how to compile OpenSSL on a Microsoft Windows system and how 
+to link ClamAV against OpenSSL.
+
+Read More here:
+     http://blog.clamav.net/2014/07/compiling-openssl-for-windows.html
+
 Starting from version 0.98 the windows version of ClamAV requires all the
 input to be UTF-8 encoded.
 This affects:


### PR DESCRIPTION
Installed clamav 0.98.5 windows build from sourceforge

Using my 0.98.4 clamd.conf caused clamd to crash.
Trying to debug/isolate this had clamdscan failing to connect to clamd.

Built locally on windows and fixed these issues.