### PR TITLE
Allow freshclam downloadmanager to return FC_UPTODATE if no update was required

### DIFF
--- a/freshclam/manager.c
+++ b/freshclam/manager.c
@@ -2893,5 +2893,5 @@ downloadmanager (const struct optstruct *opts, const char *hostname,
     if (newver)
         free (newver);
 
-    return 0;
+    return updated ? 0 : FC_UPTODATE;
 }


### PR DESCRIPTION
Useful for callers of this method to differentiate between a successful update or no update required.