### PR TITLE
clamscan: Add --jobs option for parallel scanning

### DIFF
--- a/clamscan/clamscan.c
+++ b/clamscan/clamscan.c
@@ -56,6 +56,7 @@ void help(void);
 struct s_info info;
 short recursion = 0, bell = 0;
 short printinfected = 0, printclean = 1;
+int jobs;
 
 int main(int argc, char **argv)
 {
@@ -154,6 +155,8 @@ int main(int argc, char **argv)
 	exit(2);
     }
 
+    jobs = optget(opts, "jobs")->numarg;
+
     memset(&info, 0, sizeof(struct s_info));
 
     gettimeofday(&t1, NULL);
@@ -216,6 +219,7 @@ void help(void)
     mprintf("    --infected            -i             Only print infected files\n");
     mprintf("    --suppress-ok-results -o             Skip printing OK files\n");
     mprintf("    --bell                               Sound bell on virus detection\n");
+    mprintf("    --jobs=#n             -j             Number of parallel jobs to spawn\n");
     mprintf("\n");
     mprintf("    --tempdir=DIRECTORY                  Create temporary files in DIRECTORY\n");
     mprintf("    --leave-temps[=yes/no(*)]            Do not remove temporary files\n");

--- a/clamscan/global.h
+++ b/clamscan/global.h
@@ -22,6 +22,11 @@
 #ifndef __GLOBAL_H
 #define __GLOBAL_H
 
+/*
+ * This struct is passed via a pipe. Therefore, its  must not exceed
+ * PIPE_BUF, which can be as low as 512 according to POSIX, and it must
+ * not contain pointers.
+ */
 struct s_info {
     unsigned int sigs;		/* number of signatures */
     unsigned int dirs;		/* number of scanned directories */
@@ -35,5 +40,6 @@ struct s_info {
 extern struct s_info info;
 extern short recursion, bell;
 extern short printinfected, printclean;
+extern int jobs;
 
 #endif

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -45,6 +45,9 @@ Skip printing OK files
 \fB\-\-bell\fR
 Sound bell on virus detection.
 .TP
+\fB\-j NUM, \-\-jobs=NUM\fR
+Spawn NUM processes to scan files in parallel.
+.TP
 \fB\-\-tempdir=DIRECTORY\fR
 Create temporary files in DIRECTORY. Directory must be writable for the '@CLAMAVUSER@' user or unprivileged user running clamscan.
 .TP

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -151,6 +151,7 @@ const struct clam_option __clam_options[] = {
     { NULL, "no-trace-showsource", 's', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMBC, "Don't show source line during tracing",""},
 
     { NULL, "archive-verbose", 'a', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMSCAN, "", ""},
+    { NULL, "jobs", 'j', CLOPT_TYPE_NUMBER, MATCH_NUMBER, 0, NULL, 0, OPT_CLAMSCAN, "Number of parallel jobs to spawn", ""},
 
     /* cmdline only - deprecated */
     { NULL, "bytecode-trust-all", 't', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMSCAN | OPT_DEPRECATED, "", ""},


### PR DESCRIPTION
When --jobs=N is given, build a list of files first and then spawn N
children to scan the files in parallel. The main process writes indexes
of to-be-scanned files to a pipe and the children all read from the
other end of the pipe and scan the given files. No attempt is made to
synchronize the output of the children, so the --jobs option is best
used together with --infected.

Signed-off-by: Michal Marek mmarek@suse.com
